### PR TITLE
Feat,Update: 유저 회원가입, 중복확인

### DIFF
--- a/src/main/java/hongik/pcrc/gotbetterserver/application/service/user/UserOperationUseCase.java
+++ b/src/main/java/hongik/pcrc/gotbetterserver/application/service/user/UserOperationUseCase.java
@@ -4,6 +4,4 @@ import hongik.pcrc.gotbetterserver.application.domain.User;
 
 public interface UserOperationUseCase {
     User createUser(User user);
-
-    boolean checkUserIdDuplicate(String userId);
 }

--- a/src/main/java/hongik/pcrc/gotbetterserver/application/service/user/UserReadUseCase.java
+++ b/src/main/java/hongik/pcrc/gotbetterserver/application/service/user/UserReadUseCase.java
@@ -1,9 +1,8 @@
 package hongik.pcrc.gotbetterserver.application.service.user;
 
-import hongik.pcrc.gotbetterserver.application.domain.User;
-
 public interface UserReadUseCase {
 
+    boolean checkUserIdDuplicate(String userId);
 
-
+    boolean checkUserNicknameDuplicate(String nickname);
 }

--- a/src/main/java/hongik/pcrc/gotbetterserver/application/service/user/UserService.java
+++ b/src/main/java/hongik/pcrc/gotbetterserver/application/service/user/UserService.java
@@ -6,23 +6,32 @@ import hongik.pcrc.gotbetterserver.exception.MessageType;
 import hongik.pcrc.gotbetterserver.infrastructure.persistance.mysql.entity.UserEntity;
 import hongik.pcrc.gotbetterserver.infrastructure.persistance.mysql.repository.UserRepository;
 import lombok.AllArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
 @Service
 @AllArgsConstructor
-public class UserService implements UserOperationUseCase{
+public class UserService implements UserOperationUseCase, UserReadUseCase {
 
     private final UserRepository userRepository;
+
     @Override
     public User createUser(User user) {
+
+        // check isDuplicate userId
         Optional<UserEntity> userEntityByUserId = userRepository.findUserEntityByUserId(user.getUserId());
 
         if (userEntityByUserId.isPresent()) {
-            throw new GotbetterException(MessageType.DUPLICATED_ID);
+            throw new GotbetterException(MessageType.DUPLICATED_USER_ID);
         }
+
+        // check isDuplicate nickname
+        Optional<UserEntity> userEntityByNickname = userRepository.findUserEntityByNickname(user.getNickname());
+        if (userEntityByNickname.isPresent()) {
+            throw new GotbetterException(MessageType.DUPLICATE_NICKNAME);
+        }
+
         return userRepository.save(new UserEntity(user)).toUser();
     }
 
@@ -30,4 +39,11 @@ public class UserService implements UserOperationUseCase{
     public boolean checkUserIdDuplicate(String userId) {
         return userRepository.findUserEntityByUserId(userId).isPresent();
     }
+
+    @Override
+    public boolean checkUserNicknameDuplicate(String nickname) {
+        return userRepository.findUserEntityByNickname(nickname).isPresent();
+    }
+
+
 }

--- a/src/main/java/hongik/pcrc/gotbetterserver/exception/MessageType.java
+++ b/src/main/java/hongik/pcrc/gotbetterserver/exception/MessageType.java
@@ -5,10 +5,19 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum MessageType {
-    BAD_REQUEST ("Check API request URL protocol, parameter, etc. for errors", HttpStatus.BAD_REQUEST),
-    NOT_FOUND ("No data was found for the server. Please refer  to parameter description.", HttpStatus.NOT_FOUND),
-    INTERNAL_SERVER_ERROR ("An error occurred inside the server.", HttpStatus.INTERNAL_SERVER_ERROR),
-    DUPLICATED_ID("Duplicated user ID", HttpStatus.CONFLICT);
+
+    BAD_REQUEST("Check API request URL protocol, parameter, etc. for errors", HttpStatus.BAD_REQUEST),
+
+    // User signup 400
+    BAD_USER_ID_PATTERN("UserID must be 5-20 characters, lowercase letters, numbers, and special symbols (_), (-) only.", HttpStatus.BAD_REQUEST),
+    BAD_PASSWORD_PATTERN("Password must be 8 to 16 characters of upper and lowercase letters, numbers, and special characters.", HttpStatus.BAD_REQUEST),
+    BAD_NICKNAME_PATTERN("Nickname must be 4-12 characters", HttpStatus.BAD_REQUEST),
+    DUPLICATED_USER_ID("Duplicated userId", HttpStatus.CONFLICT),
+    DUPLICATE_NICKNAME("Duplicated Nickname", HttpStatus.CONFLICT),
+
+    NOT_FOUND("No data was found for the server. Please refer  to parameter description.", HttpStatus.NOT_FOUND),
+    INTERNAL_SERVER_ERROR("An error occurred inside the server.", HttpStatus.INTERNAL_SERVER_ERROR);
+
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/hongik/pcrc/gotbetterserver/infrastructure/persistance/mysql/repository/UserRepository.java
+++ b/src/main/java/hongik/pcrc/gotbetterserver/infrastructure/persistance/mysql/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends CrudRepository<UserEntity, Integer> {
     Optional<UserEntity> findUserEntityByUserId(String userId);
+
+    Optional<UserEntity> findUserEntityByNickname(String userId);
 }

--- a/src/main/java/hongik/pcrc/gotbetterserver/ui/controller/UserController.java
+++ b/src/main/java/hongik/pcrc/gotbetterserver/ui/controller/UserController.java
@@ -7,16 +7,22 @@ import hongik.pcrc.gotbetterserver.exception.MessageType;
 import hongik.pcrc.gotbetterserver.ui.requestBody.user.UserCreateRequest;
 import hongik.pcrc.gotbetterserver.ui.view.ApiResponseView;
 import hongik.pcrc.gotbetterserver.ui.view.user.UserView;
+import jakarta.annotation.Nullable;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
 @RestController
 @AllArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/users")
 public class UserController {
 
     private final UserService userService;
@@ -24,10 +30,33 @@ public class UserController {
     private final PasswordEncoder passwordEncoder;
 
 
-    @PostMapping("/users")
+    @PostMapping("")
     public ResponseEntity<ApiResponseView<UserView>> signup(@RequestBody @Validated UserCreateRequest createRequest) {
 
-        // password encode
+        // check id pattern
+        String userIdPattern = "^[a-z0-9_-]{5,20}$";
+        Matcher userIdMatcher = Pattern.compile(userIdPattern)
+                .matcher(createRequest.getUserId());
+
+        if (!userIdMatcher.matches()) {
+            throw new GotbetterException(MessageType.BAD_USER_ID_PATTERN);
+        }
+
+        // check password pattern
+        String passwordPattern = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()-_=+\\\\|{};:'\",<.>/?])[A-Za-z\\d!@#$%^&*()-_=+\\\\|{};:'\",<.>/?]{8,16}$";
+        Matcher passwordMatcher = Pattern.compile(passwordPattern)
+                .matcher(createRequest.getPassword());
+
+        if (!passwordMatcher.matches()) {
+            throw new GotbetterException(MessageType.BAD_PASSWORD_PATTERN);
+        }
+
+        // check nickname pattern
+        if (createRequest.getNickname().length() < 4 || createRequest.getNickname().length() > 12) {
+            throw new GotbetterException(MessageType.BAD_NICKNAME_PATTERN);
+        }
+
+        // password encode before store
         String encodedPassword = passwordEncoder.encode(createRequest.getPassword());
 
         User createdUser = userService.createUser(
@@ -44,17 +73,54 @@ public class UserController {
 
     }
 
-    @GetMapping("/users")
-    public ResponseEntity<ApiResponseView<UserView>> checkDuplicate(@RequestParam String userId) {
-        boolean isDuplicate = userService.checkUserIdDuplicate(userId);
+    @GetMapping("/duplicate")
+    public ResponseEntity<ApiResponseView<UserView>> checkDuplicate(@RequestParam @Nullable String userId, @RequestParam @Nullable String nickname) {
 
-        if (isDuplicate) {
-            throw new GotbetterException(MessageType.DUPLICATED_ID);
+        if (userId != null && nickname != null) {
+            throw new GotbetterException(MessageType.BAD_REQUEST);
         }
 
-        User passUserId = User.builder().userId(userId).build();
+        boolean isDuplicate;
+        User result = null;
+        // check is userId duplicate
+        if (userId != null) {
+
+            if(userId.isBlank()) {
+                throw new GotbetterException(MessageType.BAD_USER_ID_PATTERN);
+            }
+
+            isDuplicate = userService.checkUserIdDuplicate(userId);
+            if (isDuplicate) {
+                throw new GotbetterException(MessageType.DUPLICATED_USER_ID);
+            }
+
+            result = User.builder()
+                    .userId(userId)
+                    .build();
+        }
+
+        // check is nickname duplicate
+        if (nickname != null) {
+
+            if(nickname.isBlank()) {
+                throw new GotbetterException(MessageType.BAD_NICKNAME_PATTERN);
+            }
+
+            isDuplicate = userService.checkUserNicknameDuplicate(nickname);
+            if (isDuplicate) {
+                throw new GotbetterException(MessageType.DUPLICATE_NICKNAME);
+            }
+            result = User.builder()
+                    .nickname(nickname)
+                    .build();
+        }
+
+        if (result == null) {
+            throw new GotbetterException(MessageType.INTERNAL_SERVER_ERROR);
+        }
+
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(new ApiResponseView<>(new UserView(passUserId)));
+                .body(new ApiResponseView<>(new UserView(result)));
     }
 }

--- a/src/main/java/hongik/pcrc/gotbetterserver/ui/requestBody/package-info.java
+++ b/src/main/java/hongik/pcrc/gotbetterserver/ui/requestBody/package-info.java
@@ -1,1 +1,0 @@
-package hongik.pcrc.gotbetterserver.ui.requestBody;

--- a/src/main/java/hongik/pcrc/gotbetterserver/ui/requestBody/user/UserCheckDuplicateRequest.java
+++ b/src/main/java/hongik/pcrc/gotbetterserver/ui/requestBody/user/UserCheckDuplicateRequest.java
@@ -1,0 +1,16 @@
+package hongik.pcrc.gotbetterserver.ui.requestBody.user;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class UserCheckDuplicateRequest {
+
+    private String userId;
+
+    private String nickname;
+}

--- a/src/main/java/hongik/pcrc/gotbetterserver/ui/requestBody/user/UserCreateRequest.java
+++ b/src/main/java/hongik/pcrc/gotbetterserver/ui/requestBody/user/UserCreateRequest.java
@@ -5,19 +5,15 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.hibernate.validator.constraints.Length;
 
 @Getter
 @ToString
 @NoArgsConstructor
 public class UserCreateRequest {
     @NotNull
-    @Length(max = 12)
     private String userId;
     @NotBlank
-    @Length(max = 20)
     private String password;
     @NotBlank
-    @Length(max = 10)
     private String nickname;
 }

--- a/src/test/java/hongik/pcrc/gotbetterserver/application/service/user/UserServiceTest.java
+++ b/src/test/java/hongik/pcrc/gotbetterserver/application/service/user/UserServiceTest.java
@@ -1,17 +1,12 @@
 package hongik.pcrc.gotbetterserver.application.service.user;
 
 import hongik.pcrc.gotbetterserver.application.domain.User;
-import hongik.pcrc.gotbetterserver.infrastructure.persistance.mysql.repository.UserRepository;
 import jakarta.transaction.Transactional;
-import org.aspectj.lang.annotation.Before;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -25,7 +20,7 @@ class UserServiceTest {
         // given
         User userA = User.builder()
                 .id(1)
-                .userId("userA")
+                .userId("testUserA")
                 .password("1234")
                 .nickname("hello")
                 .build();
@@ -33,7 +28,6 @@ class UserServiceTest {
         User user = userService.createUser(userA);
         // then
         assertThat(user.getUserId()).isEqualTo("userA");
-
     }
 
     @Test
@@ -41,7 +35,7 @@ class UserServiceTest {
         // given
         User userA = User.builder()
                 .id(1)
-                .userId("userA")
+                .userId("철수")
                 .password("1234")
                 .nickname("hello")
                 .build();
@@ -50,8 +44,12 @@ class UserServiceTest {
         // when
         boolean check1 = userService.checkUserIdDuplicate("userA");
         boolean check2 = userService.checkUserIdDuplicate("hello");
+        boolean check3 = userService.checkUserIdDuplicate("usera");
+        boolean check4 = userService.checkUserIdDuplicate("철수");
         // then
-        assertThat(check1).isTrue();
+        assertThat(check1).isFalse();
         assertThat(check2).isFalse();
+        assertThat(check3).isFalse();
+        assertThat(check4).isTrue();
     }
 }

--- a/src/test/java/hongik/pcrc/gotbetterserver/ui/controller/UserControllerTest.java
+++ b/src/test/java/hongik/pcrc/gotbetterserver/ui/controller/UserControllerTest.java
@@ -3,10 +3,11 @@ package hongik.pcrc.gotbetterserver.ui.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hongik.pcrc.gotbetterserver.application.domain.User;
 import hongik.pcrc.gotbetterserver.application.service.user.UserService;
-import hongik.pcrc.gotbetterserver.infrastructure.persistance.mysql.entity.UserEntity;
+import hongik.pcrc.gotbetterserver.exception.MessageType;
 import jakarta.transaction.Transactional;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,11 +15,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Slf4j
@@ -38,69 +43,193 @@ class UserControllerTest {
     public static final String BASE_URI = "/api/v1";
 
     @Test
+    @Transactional
     @DisplayName("회원가입 테스트")
     void signup() throws Exception {
         // given
-        int userId = 1;
-        String password = "1234";
-        String nickname = "userA";
+
+        DummyUserCreateRequest userIdWithCapital = DummyUserCreateRequest.builder()
+                .userId("testUserA")
+                .password("qwer1234!")
+                .nickname("테스트유저1")
+                .build();
+        DummyUserCreateRequest userIdWithKorean = DummyUserCreateRequest.builder()
+                .userId("안녕하세요")
+                .password("qwer1234!")
+                .nickname("테스트유저2")
+                .build();
+        DummyUserCreateRequest userIdShort = DummyUserCreateRequest.builder()
+                .userId("hel")
+                .password("qwer1234!")
+                .nickname("테스트유저3")
+                .build();
+        DummyUserCreateRequest ok = DummyUserCreateRequest.builder()
+                .userId("helloworld")
+                .password("Qwer1234!")
+                .nickname("테스트유저4")
+                .build();
         // when
-        String requestBody = mapper.writeValueAsString(
-                DummyUserCreateRequest.builder()
-                        .userId(userId)
-                        .nickname(nickname)
-                        .build()
-        );
 
         // then
         mvc.perform(post(BASE_URI + "/users")
-                        .content(requestBody)
                         .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(userIdWithCapital))
                 )
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andDo(result -> {
+                    assertThat(result.getResponse()
+                            .getContentAsString(StandardCharsets.UTF_8))
+                            .contains(MessageType.BAD_USER_ID_PATTERN.name());
+                });
+
+
+        mvc.perform(post(BASE_URI + "/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(userIdShort))
+                )
+                .andExpect(status().isBadRequest())
+                .andDo(result -> {
+                    assertThat(result.getResponse()
+                            .getContentAsString(StandardCharsets.UTF_8))
+                            .contains(MessageType.BAD_USER_ID_PATTERN.name());
+                });
+
+        mvc.perform(post(BASE_URI + "/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(userIdWithKorean))
+                )
+                .andExpect(status().isBadRequest())
+                .andDo(result -> {
+                    assertThat(result.getResponse()
+                            .getContentAsString(StandardCharsets.UTF_8))
+                            .contains(MessageType.BAD_USER_ID_PATTERN.name());
+                });
+
+
+        mvc.perform(post(BASE_URI + "/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .content(mapper.writeValueAsString(ok))
+                )
+                .andExpect(status().isCreated())
+                .andDo((result) -> {
+                    DummyUserCreateRequest nicknameConflict = DummyUserCreateRequest.builder()
+                            .userId("helloworld2")
+                            .password("Qwer1234!")
+                            .nickname("테스트유저4")
+                            .build();
+                    mvc.perform(post(BASE_URI + "/users")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(mapper.writeValueAsString(nicknameConflict))
+                            ).andExpect(status().isConflict())
+                            .andDo(result1 -> {
+                                assertThat(result1.getResponse()
+                                        .getContentAsString(StandardCharsets.UTF_8))
+                                        .contains(MessageType.DUPLICATE_NICKNAME.name());
+                            });
+                });
+
 
     }
 
     @Test
     @Transactional
-    @DisplayName("아이디 중복확인 테스트")
+    @DisplayName("중복확인 테스트")
     void checkDuplicate() throws Exception {
         // given
         User userA = User.builder()
-                .userId("hello")
-                .password("1234")
-                .nickname("userA")
+                .userId("helloworld")
+                .password("qwer1234!")
+                .nickname("테스트유저1")
                 .build();
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("userId", "fjdk");
+        params.add("nickname", "fjdk");
         // when
         userService.createUser(userA);
         // then
-        mvc.perform(get(BASE_URI + "/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .param("userId", "hello")
-                )
-                .andExpect(status().isConflict());
 
-        mvc.perform(get(BASE_URI + "/users")
+        // 400 Error: included userId and nickname
+        mvc.perform(get(BASE_URI + "/users/duplicate")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .param("userId", "world"))
-                .andExpect(status().isOk())
-                .andExpect(result -> {
-                    MockHttpServletResponse response = result.getResponse();
-                    log.info("result {}", response.getContentAsString());
+                        .params(params)
+                )
+                .andExpect(status().isBadRequest())
+                .andDo(result -> {
+                    assertThat(result.getResponse()
+                            .getContentAsString(StandardCharsets.UTF_8))
+                            .contains(MessageType.BAD_REQUEST.name());
                 });
 
-        mvc.perform(get(BASE_URI + "/users")
+        // 409 Error: nickname conflict
+        mvc.perform(get(BASE_URI + "/users/duplicate")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .param("hello", "world")
+                        .param("nickname", "테스트유저1")
+                )
+                .andExpect(status().isConflict())
+                .andDo(result -> {
+                    assertThat(result.getResponse()
+                            .getContentAsString(StandardCharsets.UTF_8))
+                            .contains(MessageType.DUPLICATE_NICKNAME.name());
+                });
+
+        // 200 Ok
+        mvc.perform(get(BASE_URI + "/users/duplicate")
+                        .param("nickname", "테스트유저")
+                )
+                .andExpect(status().isOk())
+                .andDo(result -> {
+                    assertThat(result.getResponse()
+                            .getContentAsString(StandardCharsets.UTF_8))
+                            .contains("테스트유저");
+                });
+
+        // 400 Error: nickname with blank
+        mvc.perform(get(BASE_URI + "/users/duplicate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("nickname", "")
+                )
+                .andExpect(status().isBadRequest());
+
+        // 409 Error: userId duplicate
+        mvc.perform(get(BASE_URI + "/users/duplicate")
+                        .param("userId", "helloworld")
+                )
+                .andExpect(status().isConflict())
+                .andDo(result -> {
+                    assertThat(result.getResponse()
+                            .getContentAsString(StandardCharsets.UTF_8))
+                            .contains(MessageType.DUPLICATED_USER_ID.name());
+                });
+
+        // 200 Ok
+        mvc.perform(get(BASE_URI + "/users/duplicate")
+                        .param("userId", "helloworld2")
+                )
+                .andExpect(status().isOk())
+                .andDo(result -> {
+                    assertThat(result.getResponse()
+                            .getContentAsString(StandardCharsets.UTF_8))
+                            .contains("helloworld2");
+                });
+
+        // 400 Error: userId with blank
+        mvc.perform(get(BASE_URI + "/users/duplicate")
+                        .param("userId", "")
                 )
                 .andExpect(status().isBadRequest());
 
     }
 
+
+
     @Getter
     @Builder
+    @ToString
     static class DummyUserCreateRequest {
-        private int userId;
+        private String userId;
+        private String password;
         private String nickname;
     }
 }


### PR DESCRIPTION
## 어떤 이유로 MR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [x] 코드 수정
- [ ] 배포
- [ ] 기타

## Summary
- 닉네임 중복확인 기능 추가
- 회원가입, 중복확인 예외처리 추가

## Changes
- 기존에 OperationUseCase에 위치했던 중복확인 기능 ReadUseCase로 위치 변경
- 중복확인
    - 기존 엔드포인트: /users
    - 변경 된 엔드포인트: /users/duplicate
    - 변경된 엔드포인트에서 userId, nickname 쿼리 param을 통해 중복확인 처리
    - userId, nickname이 동시에 들어올 경우 예외로 처리함(400반환)
    - 또한 isBlank()일 경우 400 반환

## Check list
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?

## Issue number and link
#5 
#6 

